### PR TITLE
👐🏽 Tweak built-in GraphQL Handler

### DIFF
--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -1,1 +1,1 @@
-export { createQueryHandler } from './handler';
+export { createGraphQLHandler } from './handler';

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -1,0 +1,22 @@
+import { GraphQLSchema, GraphQLArgs, graphql } from 'graphql';
+import { ResolverMapMiddleware, ResolverMap } from '../types';
+import { PackState, PackOptions } from '../pack/types';
+
+export interface GraphQLHandler {
+  state: PackState;
+  dependencies: PackState['dependencies'];
+  graphqlSchema: GraphQLSchema;
+  middlewares: ResolverMapMiddleware[];
+  packedResolverMap: ResolverMap;
+
+  query: (
+    query: string,
+    variables?: Record<string, unknown>,
+    graphqlArgs?: Partial<GraphQLArgs>,
+  ) => ReturnType<typeof graphql>;
+}
+
+export type createGraphQLHandlerOptions = Partial<PackOptions> & {
+  middlewares?: ResolverMapMiddleware[];
+  dependencies: PackOptions['dependencies'] & { graphqlSchema: GraphQLSchema | string };
+};

--- a/src/mirage/middleware/patch-auto-field-resolvers.ts
+++ b/src/mirage/middleware/patch-auto-field-resolvers.ts
@@ -1,11 +1,12 @@
 import { GraphQLSchema } from 'graphql';
 import { mirageRootQueryResolver } from '../resolvers/root-query';
 import { mirageObjectResolver } from '../resolvers/object';
-import { ResolverMapMiddleware, PackOptions, ResolverMap } from '../../types';
+import { ResolverMapMiddleware, ResolverMap } from '../../types';
 import { walk } from '../../resolver-map/walk';
 import { isRootQueryType, isRootMutationType, isInternalType } from '../../graphql/utils';
 import { resolverExistsInResolverMap, addResolverToMap } from '../../resolver-map/utils';
 import { IncludeExcludeMiddlewareOptions, defaultIncludeExcludeOptions } from '../../resolver-map/types';
+import { PackOptions } from '../../pack';
 
 export function patchAutoFieldResolvers(
   options: IncludeExcludeMiddlewareOptions = defaultIncludeExcludeOptions,

--- a/src/mirage/middleware/patch-auto-field-resolvers.ts
+++ b/src/mirage/middleware/patch-auto-field-resolvers.ts
@@ -6,7 +6,7 @@ import { walk } from '../../resolver-map/walk';
 import { isRootQueryType, isRootMutationType, isInternalType } from '../../graphql/utils';
 import { resolverExistsInResolverMap, addResolverToMap } from '../../resolver-map/utils';
 import { IncludeExcludeMiddlewareOptions, defaultIncludeExcludeOptions } from '../../resolver-map/types';
-import { PackOptions } from '../../pack';
+import { PackOptions } from '../../pack/types';
 
 export function patchAutoFieldResolvers(
   options: IncludeExcludeMiddlewareOptions = defaultIncludeExcludeOptions,

--- a/src/mirage/middleware/patch-auto-type-resolvers.ts
+++ b/src/mirage/middleware/patch-auto-type-resolvers.ts
@@ -9,8 +9,8 @@ import {
 import { ResolverMap } from '../../types';
 import { mirageUnionResolver } from '../resolvers/union';
 import { mirageInterfaceResolver } from '../resolvers/interface';
-import { PackOptions } from '../../pack/pack';
 import { embedPackOptionsInContext } from '../../pack/utils';
+import { PackOptions } from '../../pack/types';
 
 export function patchAutoTypeResolvers(resolverMap: ResolverMap, packOptions: PackOptions): ResolverMap {
   const { graphqlSchema: schema } = packOptions.dependencies;

--- a/src/mirage/middleware/patch-auto-type-resolvers.ts
+++ b/src/mirage/middleware/patch-auto-type-resolvers.ts
@@ -6,10 +6,11 @@ import {
   isUnionType,
   isInterfaceType,
 } from 'graphql';
-import { PackOptions, ResolverMap } from '../../types';
+import { ResolverMap } from '../../types';
 import { mirageUnionResolver } from '../resolvers/union';
 import { mirageInterfaceResolver } from '../resolvers/interface';
-import { embedPackOptionsInContext } from '../../resolver-map/utils';
+import { PackOptions } from '../../pack/pack';
+import { embedPackOptionsInContext } from '../../pack/utils';
 
 export function patchAutoTypeResolvers(resolverMap: ResolverMap, packOptions: PackOptions): ResolverMap {
   const { graphqlSchema: schema } = packOptions.dependencies;

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -1,0 +1,1 @@
+export { pack } from './pack';

--- a/src/pack/pack.ts
+++ b/src/pack/pack.ts
@@ -1,7 +1,7 @@
-import { Packer, PackOptions, PackState } from '../types';
 import cloneDeep from 'lodash.clonedeep';
-import { embed } from './embed';
-import { embedPackOptionsWrapper } from './utils';
+import { embed } from '../resolver-map/embed';
+import { embedPackOptionsWrapper, normalizePackOptions } from './utils';
+import { PackOptions, Packer, PackState } from './types';
 
 export const defaultPackOptions: PackOptions = { state: {}, dependencies: {} };
 
@@ -10,18 +10,7 @@ export const pack: Packer = async (initialResolversMap = {}, middlewares = [], p
 
   // make an intial copy
   let wrappedMap = cloneDeep(initialResolversMap);
-
-  packOptions = {
-    ...packOptions,
-
-    state: {
-      ...packOptions.state,
-    },
-
-    dependencies: {
-      ...packOptions.dependencies,
-    },
-  };
+  packOptions = normalizePackOptions(packOptions);
 
   for (const middleware of middlewares) {
     wrappedMap = await middleware(wrappedMap, packOptions as PackOptions);

--- a/src/pack/types.ts
+++ b/src/pack/types.ts
@@ -1,0 +1,18 @@
+import { ResolverMapMiddleware, ResolverMap } from '../types';
+
+type NonNullDependency = object | string | boolean | symbol | number;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PackState = Record<any, any>;
+export type Packed = { resolverMap: ResolverMap; state: PackState };
+
+export type PackOptions = {
+  state: PackState;
+  dependencies: Record<string, NonNullDependency>;
+};
+
+export type Packer = (
+  initialMap: ResolverMap,
+  middlewares: ResolverMapMiddleware[],
+  packOptions?: Partial<PackOptions>,
+) => Promise<Packed>;

--- a/src/pack/utils.ts
+++ b/src/pack/utils.ts
@@ -1,0 +1,40 @@
+import { ResolverWrapper, ResolverParent, ResolverArgs, ResolverContext, ResolverInfo, Resolver } from '../types';
+import { defaultPackOptions } from './pack';
+import { PackOptions } from './types';
+
+export function normalizePackOptions(packOptions: Partial<PackOptions> = defaultPackOptions): PackOptions {
+  const normalized = {
+    ...defaultPackOptions,
+
+    dependencies: packOptions.dependencies ?? defaultPackOptions.dependencies,
+    state: packOptions.state ?? defaultPackOptions.state,
+  };
+
+  return normalized;
+}
+
+export const embedPackOptionsInContext = (
+  context: Record<string, unknown>,
+  packOptions: PackOptions,
+): Record<string, unknown> => {
+  context = context ?? {};
+  context = {
+    ...context,
+    pack: context.pack || packOptions,
+  };
+
+  return context;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const embedPackOptionsWrapper: ResolverWrapper = async (resolver, options): Promise<Resolver> => {
+  return (
+    parent: ResolverParent,
+    args: ResolverArgs,
+    context: ResolverContext,
+    info: ResolverInfo,
+  ): Promise<unknown> => {
+    context = embedPackOptionsInContext(context, options.packOptions);
+    return resolver(parent, args, context, info);
+  };
+};

--- a/src/resolver-map/embed.ts
+++ b/src/resolver-map/embed.ts
@@ -4,8 +4,9 @@ import { Resolver, ResolverWrapper, ResolverMapMiddleware, ResolverMap } from '.
 import { expand, SPECIAL_TYPE_TARGET, SPECIAL_FIELD_TARGET } from './reference/target-reference';
 import { difference } from './reference/field-reference';
 import { getTypeAndFieldDefinitions } from '../graphql/utils';
-import { embedPackOptionsWrapper, addResolverToMap } from './utils';
 import { IncludeExcludeMiddlewareOptions } from './types';
+import { embedPackOptionsWrapper } from '../pack/utils';
+import { addResolverToMap } from './utils';
 
 export type EmbedOptions = {
   wrappers?: ResolverWrapper[];

--- a/src/resolver-map/index.ts
+++ b/src/resolver-map/index.ts
@@ -1,2 +1,2 @@
-export { pack } from './pack';
+export { pack } from '../pack';
 export { extractDependencies } from '../resolver/extract-dependencies';

--- a/src/resolver-map/reference/target-reference.ts
+++ b/src/resolver-map/reference/target-reference.ts
@@ -47,7 +47,6 @@ export function expandTarget(target: TargetReference, schema: GraphQLSchema): Fi
   }
 
   const [typeTarget, fieldTarget] = target;
-
   const types = schema.getTypeMap();
 
   const filtered = Object.entries(types)

--- a/src/resolver-map/utils.ts
+++ b/src/resolver-map/utils.ts
@@ -1,45 +1,10 @@
-import {
-  ResolverMap,
-  PackOptions,
-  ResolverWrapper,
-  Resolver,
-  ResolverParent,
-  ResolverArgs,
-  ResolverContext,
-  ResolverInfo,
-} from '../types';
+import { ResolverMap, Resolver } from '../types';
 import { FieldReference } from './reference/field-reference';
 
 export function resolverExistsInResolverMap(fieldReference: FieldReference, resolverMap: ResolverMap): boolean {
   const [typeName, fieldName] = fieldReference;
   return typeof resolverMap?.[typeName]?.[fieldName] === 'function';
 }
-
-export const embedPackOptionsInContext = (
-  context: Record<string, unknown>,
-  packOptions: PackOptions,
-): Record<string, unknown> => {
-  context = context ?? {};
-  context = {
-    ...context,
-    pack: context.pack || packOptions,
-  };
-
-  return context;
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const embedPackOptionsWrapper: ResolverWrapper = async (resolver, options): Promise<Resolver> => {
-  return (
-    parent: ResolverParent,
-    args: ResolverArgs,
-    context: ResolverContext,
-    info: ResolverInfo,
-  ): Promise<unknown> => {
-    context = embedPackOptionsInContext(context, options.packOptions);
-    return resolver(parent, args, context, info);
-  };
-};
 
 export function addResolverToMap({
   resolverMap,

--- a/src/resolver/extract-dependencies.ts
+++ b/src/resolver/extract-dependencies.ts
@@ -1,4 +1,5 @@
-import { ResolverContext, PackOptions } from '../types';
+import { ResolverContext } from '../types';
+import { PackOptions } from '../pack/types';
 
 type PackDependencies = PackOptions['dependencies'];
 type PackedContext = ResolverContext & {
@@ -57,7 +58,7 @@ export function extractDependencies<T>(
     throw new Error(
       `Expected to find dependencies with keys: ${missingKeys}\n` +
         'Either:\n' +
-        ' * Add to the these `dependencies` in your `createQueryHandler` or `pack` function\n' +
+        ' * Add to the these `dependencies` in your `createGraphQLHandler` or `pack` function\n' +
         ' * Use { required : false } as the third argument to `extractDependencies` and allow for these to be optional dependencies',
     );
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ import {
   GraphQLTypeResolver,
 } from 'graphql';
 
+import { PackOptions } from './pack/types';
+
 // Resolvers Shorthands
 
 export type Primitive = string | boolean | number;
@@ -44,20 +46,4 @@ export type ResolverMap<TFieldResolver = Resolver, TTypeResolver = GraphQLTypeRe
   } & { __resolveType?: TTypeResolver }; // the convention of using __resolveType on a ResolverMap is borrowed from `graphql-tools`
 };
 
-export type PackState = Record<any, any>;
-
-type NonNullDependency = object | string | boolean | symbol | number;
-export type PackOptions = {
-  state: PackState;
-  dependencies: Record<string, NonNullDependency>;
-};
-
 export type ResolverMapMiddleware = (map: ResolverMap, packOptions: PackOptions) => ResolverMap | Promise<ResolverMap>;
-
-export type Packed = { resolverMap: ResolverMap; state: PackState };
-
-export type Packer = (
-  initialMap: ResolverMap,
-  middlewares: ResolverMapMiddleware[],
-  packOptions?: Partial<PackOptions>,
-) => Promise<Packed>;

--- a/test/integration/mirage-auto-resolve-object-types.test.ts
+++ b/test/integration/mirage-auto-resolve-object-types.test.ts
@@ -4,7 +4,7 @@
 import { Model, Server, hasMany, belongsTo } from 'miragejs';
 import { expect } from 'chai';
 import { patchAutoFieldResolvers } from '../../src/mirage/middleware/patch-auto-field-resolvers';
-import { createQueryHandler } from '../../src/graphql';
+import { createGraphQLHandler } from '../../src/graphql';
 import { MirageGraphQLMapper } from '../../src/mirage/mapper';
 
 // patchAutoFieldResolvers middleware covers both auto-resolving of
@@ -54,7 +54,7 @@ describe('integration/mirage-auto-resolve-types', function () {
     });
 
     it('returns a scalar from a model attr', async () => {
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -87,7 +87,7 @@ describe('integration/mirage-auto-resolve-types', function () {
     it('returns a scalar from a field filter', async () => {
       mirageMapper.addFieldFilter(['Person', 'name'], () => 'Person Name Override');
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -152,7 +152,7 @@ describe('integration/mirage-auto-resolve-types', function () {
     it('returns a collection of relationships from a model', async () => {
       mirageMapper.addFieldFilter(['Query', 'person'], () => rootPerson);
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -210,7 +210,7 @@ describe('integration/mirage-auto-resolve-types', function () {
           return models.filter((model: any) => model?.name?.startsWith('M'));
         });
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -271,7 +271,7 @@ describe('integration/mirage-auto-resolve-types', function () {
 
       mirageMapper.addFieldFilter(['Query', 'person'], () => rootPerson);
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -326,7 +326,7 @@ describe('integration/mirage-auto-resolve-types', function () {
       mirageMapper.addFieldFilter(['Query', 'person'], () => rootPerson);
       mirageMapper.addFieldFilter(['Person', 'bestFriend'], () => bestFriendOverride);
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],

--- a/test/integration/mirage-auto-resolve-root-query.test.ts
+++ b/test/integration/mirage-auto-resolve-root-query.test.ts
@@ -4,7 +4,7 @@
 import { Model, Server } from 'miragejs';
 import { expect } from 'chai';
 import { patchAutoFieldResolvers } from '../../src/mirage/middleware/patch-auto-field-resolvers';
-import { createQueryHandler } from '../../src/graphql';
+import { createGraphQLHandler } from '../../src/graphql';
 import { MirageGraphQLMapper } from '../../src/mirage/mapper';
 
 // patchAutoFieldResolvers middleware covers both auto-resolving of
@@ -31,7 +31,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     it('can return a scalar using a filter field', async function () {
       const mirageMapper = new MirageGraphQLMapper().addFieldFilter(['Query', 'personName'], () => 'Grace Hopper');
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -64,7 +64,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         'Anita Borg',
       ]);
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -92,7 +92,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     });
 
     it('throws an error when a field filter is not provided', async function () {
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -158,7 +158,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     `;
 
     it('by default returns an array of all models', async function () {
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -187,7 +187,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         return models.filter((model: any) => ['wilma', 'fred'].includes(model.name));
       });
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -217,7 +217,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         return [{ name: 'Ada Lovelace' }, { name: 'Grace Hopper' }];
       });
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -247,7 +247,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         return null;
       });
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -295,7 +295,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         name: 'fred',
       });
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -320,7 +320,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     });
 
     it('returns null when there are no models', async function () {
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -347,7 +347,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     it('returns null from field filter', async function () {
       const mirageMapper = new MirageGraphQLMapper().addFieldFilter(['Query', 'person'], () => null);
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -377,7 +377,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         name: 'Grace Hopper',
       }));
 
-      const handler = await createQueryHandler(
+      const handler = await createGraphQLHandler(
         {},
         {
           middlewares: [patchAutoFieldResolvers()],
@@ -420,7 +420,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
       });
 
       it('when no field filter exists it throws an error', async function () {
-        const handler = await createQueryHandler(
+        const handler = await createGraphQLHandler(
           {},
           {
             middlewares: [patchAutoFieldResolvers()],
@@ -451,7 +451,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
             return models[0];
           });
 
-          const handler = await createQueryHandler(
+          const handler = await createGraphQLHandler(
             {},
             {
               middlewares: [patchAutoFieldResolvers()],
@@ -483,7 +483,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
             return models;
           });
 
-          const handler = await createQueryHandler(
+          const handler = await createGraphQLHandler(
             {},
             {
               middlewares: [patchAutoFieldResolvers()],

--- a/test/integration/mirage-auto-resolver.test.ts
+++ b/test/integration/mirage-auto-resolver.test.ts
@@ -7,7 +7,7 @@ import defaultScenario from './test-helpers/mirage-sample/fixtures';
 import { graphqlSchema } from './test-helpers/test-schema';
 import { MirageGraphQLMapper } from '../../src/mirage/mapper';
 import { ResolverMap } from '../../src/types';
-import { createQueryHandler } from '../../src/graphql';
+import { createGraphQLHandler } from '../../src/graphql';
 
 describe('integration/mirage-auto-resolver', function () {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -29,7 +29,7 @@ describe('integration/mirage-auto-resolver', function () {
 
     mirageServer.db.loadData(defaultScenario);
 
-    const handler = await createQueryHandler(defaultResolvers, {
+    const handler = await createGraphQLHandler(defaultResolvers, {
       middlewares: [patchAutoResolvers()],
       dependencies: {
         mirageMapper,
@@ -114,6 +114,7 @@ describe('integration/mirage-auto-resolver', function () {
     }`;
 
     const result = await graphQLHandler(query);
+
     expect(result).to.deep.equal({
       data: {
         person: {
@@ -534,7 +535,7 @@ describe('integration/mirage-auto-resolver', function () {
 
     context('with Query.allPersons included', () => {
       beforeEach(async () => {
-        const handler = await createQueryHandler(
+        const handler = await createGraphQLHandler(
           {},
           {
             middlewares: [
@@ -577,7 +578,7 @@ describe('integration/mirage-auto-resolver', function () {
 
     context('with Query.allPersons excluded', () => {
       beforeEach(async () => {
-        const handler = await createQueryHandler(
+        const handler = await createGraphQLHandler(
           {},
           {
             middlewares: [

--- a/test/integration/mirage-relay.test.ts
+++ b/test/integration/mirage-relay.test.ts
@@ -4,9 +4,9 @@
 import { Model, Server, hasMany } from 'miragejs';
 import { expect } from 'chai';
 import { patchAutoFieldResolvers } from '../../src/mirage/middleware/patch-auto-field-resolvers';
-import { createQueryHandler } from '../../src/graphql';
+import { createGraphQLHandler } from '../../src/graphql';
 import { MirageGraphQLMapper } from '../../src/mirage/mapper';
-import { QueryHandler } from '../../src/graphql/handler';
+import { GraphQLHandler } from '../../src/graphql/types';
 
 const schemaString = `
   schema {
@@ -44,7 +44,7 @@ const schemaString = `
 describe('integration/mirage-relay', function () {
   let mirageServer: Server;
   let mirageMapper: MirageGraphQLMapper;
-  let handler: QueryHandler;
+  let handler: GraphQLHandler;
 
   beforeEach(async () => {
     mirageServer = new Server({
@@ -77,7 +77,7 @@ describe('integration/mirage-relay', function () {
 
     mirageMapper = new MirageGraphQLMapper().addFieldFilter(['Query', 'person'], () => rootPerson);
 
-    handler = await createQueryHandler(
+    handler = await createGraphQLHandler(
       {},
       {
         middlewares: [patchAutoFieldResolvers()],

--- a/test/integration/mirage-static-resolvers.test.ts
+++ b/test/integration/mirage-static-resolvers.test.ts
@@ -3,16 +3,16 @@ import { graphqlSchema } from './test-helpers/test-schema';
 import defaultResolvers from './test-helpers/mirage-static-resolvers';
 import { server as mirageServer } from './test-helpers/mirage-sample';
 import defaultScenario from './test-helpers/mirage-sample/fixtures';
-import { createQueryHandler } from '../../src/graphql';
-import { QueryHandler } from '../../src/graphql/handler';
+import { createGraphQLHandler } from '../../src/graphql';
+import { GraphQLHandler } from '../../src/graphql/types';
 
 describe('integration/mirage-static-resolvers', function () {
-  let handler: QueryHandler;
+  let handler: GraphQLHandler;
 
   beforeEach(async () => {
     mirageServer.db.loadData(defaultScenario);
 
-    handler = await createQueryHandler(defaultResolvers, {
+    handler = await createGraphQLHandler(defaultResolvers, {
       state: {},
       dependencies: {
         mirageServer,

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,6 +1,6 @@
 import { buildSchema, GraphQLObjectType } from 'graphql';
-import { PackOptions } from '../src/types';
 import { MirageGraphQLMapper } from '../src/mirage/mapper';
+import { PackOptions } from '../src/pack/pack';
 
 export const generatePackOptions: (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,6 +1,6 @@
 import { buildSchema, GraphQLObjectType } from 'graphql';
 import { MirageGraphQLMapper } from '../src/mirage/mapper';
-import { PackOptions } from '../src/pack/pack';
+import { PackOptions } from '../src/pack/types';
 
 export const generatePackOptions: (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/unit/graphql/handler.test.ts
+++ b/test/unit/graphql/handler.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { createQueryHandler, QueryHandler } from '../../../src/graphql/handler';
+import { createGraphQLHandler } from '../../../src/graphql/handler';
+import { GraphQLHandler } from '../../../src/graphql/types';
 import { ResolverMap } from '../../../src/types';
 import { buildSchema } from 'graphql';
 import { spyWrapper } from '../../../src/spy';
@@ -16,7 +17,7 @@ describe('graphql/hander', function () {
     }
   `;
 
-  let handler: QueryHandler;
+  let handler: GraphQLHandler;
   let resolverMap: ResolverMap;
 
   beforeEach(() => {
@@ -28,7 +29,7 @@ describe('graphql/hander', function () {
   });
 
   it('can execute a graphql query constructed from a schema string', async function () {
-    handler = await createQueryHandler(resolverMap, { dependencies: { graphqlSchema: schemaString } });
+    handler = await createGraphQLHandler(resolverMap, { dependencies: { graphqlSchema: schemaString } });
     const result = await handler.query(`
       {
         hello
@@ -44,7 +45,7 @@ describe('graphql/hander', function () {
 
   it('can execute a graphql query constructed from a schema instance', async function () {
     const schemaInstance = buildSchema(schemaString);
-    handler = await createQueryHandler(resolverMap, { dependencies: { graphqlSchema: schemaInstance } });
+    handler = await createGraphQLHandler(resolverMap, { dependencies: { graphqlSchema: schemaInstance } });
     const result = await handler.query(`
       {
         hello
@@ -61,7 +62,7 @@ describe('graphql/hander', function () {
   it('throws a helpful error if the schema string cannot be parsed', async function () {
     let error: null | Error = null;
     try {
-      await createQueryHandler(resolverMap, {
+      await createGraphQLHandler(resolverMap, {
         dependencies: { graphqlSchema: 'NOT A VALID GRAPHQL STRING' },
       });
     } catch (e) {
@@ -76,7 +77,7 @@ Syntax Error: Unexpected Name "NOT"`);
 
   it('returns maintains the same state object argument', async function () {
     const initialState = { key: 'value' };
-    const handler = await createQueryHandler(resolverMap, {
+    const handler = await createGraphQLHandler(resolverMap, {
       state: initialState,
       dependencies: { graphqlSchema: schemaString },
     });
@@ -88,7 +89,7 @@ Syntax Error: Unexpected Name "NOT"`);
     // using the wrapEachField middleware with the spyWrapper
     // produces a state with the spy function accessible at
     // state.spies.Query.hello
-    const handler = await createQueryHandler(resolverMap, {
+    const handler = await createGraphQLHandler(resolverMap, {
       middlewares: [embed({ wrappers: [spyWrapper] })],
       dependencies: { graphqlSchema: schemaString },
     });

--- a/test/unit/pack/utilts.test.ts
+++ b/test/unit/pack/utilts.test.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { wrapResolver } from '../../../src/resolver/wrap';
+import { embedPackOptionsWrapper } from '../../../src/pack/utils';
+
+describe('pack/utils', () => {
+  describe('#embedPackOptionsWrapper', () => {
+    it('creates a wrapped function with embedded packOptions', async () => {
+      const resolver = sinon.spy();
+
+      const wrappedResolver = await wrapResolver(resolver, [embedPackOptionsWrapper], {
+        resolverMap: {},
+        packOptions: {
+          state: {},
+          dependencies: {
+            dependency: 'here-is-a-dependency',
+          },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      wrappedResolver(null, { arg: '' }, { existing: 'other-existing-context' }, {} as any);
+      const [, , context] = resolver.firstCall.args;
+      expect(context).to.deep.equal({
+        existing: 'other-existing-context',
+        pack: {
+          state: {},
+          dependencies: {
+            dependency: 'here-is-a-dependency',
+          },
+        },
+      });
+    });
+  });
+});

--- a/test/unit/resolver-map/pack.test.ts
+++ b/test/unit/resolver-map/pack.test.ts
@@ -1,8 +1,8 @@
 import { buildSchema, GraphQLResolveInfo } from 'graphql';
 import { expect } from 'chai';
-import { pack } from '../../../src/resolver-map/pack';
 import { ResolverMapMiddleware, ResolverMap } from '../../../src/types';
 import sinon from 'sinon';
+import { pack } from '../../../src/pack';
 
 describe('resolver-map/pack', () => {
   it('reduces a set of resolvers', async () => {

--- a/test/unit/resolver/extract-dependencies.test.ts
+++ b/test/unit/resolver/extract-dependencies.test.ts
@@ -13,7 +13,7 @@ const generateMocksContextWithDependencies = (dependencies: any): any => {
 
 const missingRequiredDependencyError = `Expected to find dependencies with keys: "does not exist"
 Either:
- * Add to the these \`dependencies\` in your \`createQueryHandler\` or \`pack\` function
+ * Add to the these \`dependencies\` in your \`createGraphQLHandler\` or \`pack\` function
  * Use { required : false } as the third argument to \`extractDependencies\` and allow for these to be optional dependencies`;
 
 describe('resolvers/extract-dependencies', function () {


### PR DESCRIPTION
## Notable changes
* Move `pack` to its own top-level module
* Clean up implementation of the `graphql/handler` and abstract away parts into util functions
* Add a couple of extra tests
* Expose more on the GraphQL handler included the copied Schema that has the resolvers attached (executable)
* Expose the middlewares used
* Expose the final packed Resolver Map
* Expose pack dependencies
* Expose pack state
* `query` handler now allows for `GraphQLArgs` overrides on the 3rd object if there is any handler defaults that should be overridden