### PR TITLE
Move resolverMap into createGraphQLHandler options

### DIFF
--- a/src/graphql/handler.ts
+++ b/src/graphql/handler.ts
@@ -1,14 +1,11 @@
 import { graphql, GraphQLSchema, ExecutionResult } from 'graphql';
 import { pack } from '../pack';
-import { ResolverMap } from '../types';
 import { createSchema, attachResolversToSchema } from './utils';
 import { normalizePackOptions } from '../pack/utils';
 import { createGraphQLHandlerOptions, GraphQLHandler } from './types';
 
-export async function createGraphQLHandler(
-  resolverMap: ResolverMap = {},
-  options: createGraphQLHandlerOptions,
-): Promise<GraphQLHandler> {
+export async function createGraphQLHandler(options: createGraphQLHandlerOptions): Promise<GraphQLHandler> {
+  const resolverMap = options?.resolverMap ?? {};
   const graphqlSchema = createSchema(options?.dependencies?.graphqlSchema);
   options.dependencies.graphqlSchema = graphqlSchema;
 

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -17,6 +17,7 @@ export interface GraphQLHandler {
 }
 
 export type createGraphQLHandlerOptions = Partial<PackOptions> & {
+  resolverMap?: ResolverMap;
   middlewares?: ResolverMapMiddleware[];
   dependencies: PackOptions['dependencies'] & { graphqlSchema: GraphQLSchema | string };
 };

--- a/test/integration/mirage-auto-resolve-object-types.test.ts
+++ b/test/integration/mirage-auto-resolve-object-types.test.ts
@@ -54,20 +54,17 @@ describe('integration/mirage-auto-resolve-types', function () {
     });
 
     it('returns a scalar from a model attr', async () => {
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageServer,
-            graphqlSchema: createSchemaString(`
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageServer,
+          graphqlSchema: createSchemaString(`
               type Person {
                 name: String
               }
             `),
-          },
         },
-      );
+      });
 
       const result = await handler.query(`{
         person {
@@ -87,21 +84,18 @@ describe('integration/mirage-auto-resolve-types', function () {
     it('returns a scalar from a field filter', async () => {
       mirageMapper.addFieldFilter(['Person', 'name'], () => 'Person Name Override');
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageMapper,
-            mirageServer,
-            graphqlSchema: createSchemaString(`
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageMapper,
+          mirageServer,
+          graphqlSchema: createSchemaString(`
               type Person {
                 name: String
               }
             `),
-          },
         },
-      );
+      });
 
       const result = await handler.query(`{
         person {
@@ -152,22 +146,19 @@ describe('integration/mirage-auto-resolve-types', function () {
     it('returns a collection of relationships from a model', async () => {
       mirageMapper.addFieldFilter(['Query', 'person'], () => rootPerson);
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageMapper,
-            mirageServer,
-            graphqlSchema: createSchemaString(`
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageMapper,
+          mirageServer,
+          graphqlSchema: createSchemaString(`
               type Person {
                 name: String
                 friends: [Person!]!
               }
             `),
-          },
         },
-      );
+      });
 
       const result = await handler.query(`{
         person {
@@ -210,22 +201,19 @@ describe('integration/mirage-auto-resolve-types', function () {
           return models.filter((model: any) => model?.name?.startsWith('M'));
         });
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageMapper,
-            mirageServer,
-            graphqlSchema: createSchemaString(`
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageMapper,
+          mirageServer,
+          graphqlSchema: createSchemaString(`
               type Person {
                 name: String
                 friends: [Person!]!
               }
             `),
-          },
         },
-      );
+      });
 
       const result = await handler.query(`{
         person {
@@ -271,22 +259,19 @@ describe('integration/mirage-auto-resolve-types', function () {
 
       mirageMapper.addFieldFilter(['Query', 'person'], () => rootPerson);
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageMapper,
-            mirageServer,
-            graphqlSchema: createSchemaString(`
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageMapper,
+          mirageServer,
+          graphqlSchema: createSchemaString(`
               type Person {
                 name: String
                 bestFriend: Person
               }
             `),
-          },
         },
-      );
+      });
 
       const result = await handler.query(`{
         person {
@@ -326,22 +311,19 @@ describe('integration/mirage-auto-resolve-types', function () {
       mirageMapper.addFieldFilter(['Query', 'person'], () => rootPerson);
       mirageMapper.addFieldFilter(['Person', 'bestFriend'], () => bestFriendOverride);
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageMapper,
-            mirageServer,
-            graphqlSchema: createSchemaString(`
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageMapper,
+          mirageServer,
+          graphqlSchema: createSchemaString(`
               type Person {
                 name: String
                 bestFriend: Person
               }
             `),
-          },
         },
-      );
+      });
 
       const result = await handler.query(`{
         person {

--- a/test/integration/mirage-auto-resolve-root-query.test.ts
+++ b/test/integration/mirage-auto-resolve-root-query.test.ts
@@ -31,14 +31,12 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     it('can return a scalar using a filter field', async function () {
       const mirageMapper = new MirageGraphQLMapper().addFieldFilter(['Query', 'personName'], () => 'Grace Hopper');
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageMapper,
-            mirageServer,
-            graphqlSchema: `
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageMapper,
+          mirageServer,
+          graphqlSchema: `
             schema {
               query: Query
             }
@@ -47,9 +45,8 @@ describe('integration/mirage-auto-resolve-root-query', function () {
               # a list of persons
               personName: String!
             }`,
-          },
         },
-      );
+      });
 
       const result = await handler.query(`{
         personName
@@ -64,14 +61,12 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         'Anita Borg',
       ]);
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageMapper,
-            mirageServer,
-            graphqlSchema: `
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageMapper,
+          mirageServer,
+          graphqlSchema: `
             schema {
               query: Query
             }
@@ -80,9 +75,8 @@ describe('integration/mirage-auto-resolve-root-query', function () {
               # a list of persons
               personNames: [String!]!
             }`,
-          },
         },
-      );
+      });
 
       const result = await handler.query(`{
         personNames
@@ -92,13 +86,11 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     });
 
     it('throws an error when a field filter is not provided', async function () {
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageServer,
-            graphqlSchema: `
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageServer,
+          graphqlSchema: `
             schema {
               query: Query
             }
@@ -107,9 +99,8 @@ describe('integration/mirage-auto-resolve-root-query', function () {
               # a list of persons
               personName: String
             }`,
-          },
         },
-      );
+      });
 
       const result = await handler.query(`{
         personName
@@ -158,16 +149,13 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     `;
 
     it('by default returns an array of all models', async function () {
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageServer,
-            graphqlSchema,
-          },
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageServer,
+          graphqlSchema,
         },
-      );
+      });
 
       const result = await handler.query(`{
       allPeople {
@@ -187,17 +175,14 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         return models.filter((model: any) => ['wilma', 'fred'].includes(model.name));
       });
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageServer,
-            mirageMapper,
-            graphqlSchema,
-          },
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageServer,
+          mirageMapper,
+          graphqlSchema,
         },
-      );
+      });
 
       const result = await handler.query(`{
         allPeople {
@@ -217,17 +202,14 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         return [{ name: 'Ada Lovelace' }, { name: 'Grace Hopper' }];
       });
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageServer,
-            mirageMapper,
-            graphqlSchema,
-          },
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageServer,
+          mirageMapper,
+          graphqlSchema,
         },
-      );
+      });
 
       const result = await handler.query(`{
         allPeople {
@@ -247,17 +229,14 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         return null;
       });
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageServer,
-            mirageMapper,
-            graphqlSchema,
-          },
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageServer,
+          mirageMapper,
+          graphqlSchema,
         },
-      );
+      });
 
       const result = await handler.query(`{
         allPeople {
@@ -295,16 +274,13 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         name: 'fred',
       });
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageServer,
-            graphqlSchema,
-          },
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageServer,
+          graphqlSchema,
         },
-      );
+      });
 
       const result = await handler.query(`{
           person {
@@ -320,16 +296,13 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     });
 
     it('returns null when there are no models', async function () {
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageServer,
-            graphqlSchema,
-          },
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageServer,
+          graphqlSchema,
         },
-      );
+      });
 
       const result = await handler.query(`{
           person {
@@ -347,17 +320,14 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     it('returns null from field filter', async function () {
       const mirageMapper = new MirageGraphQLMapper().addFieldFilter(['Query', 'person'], () => null);
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageMapper,
-            mirageServer,
-            graphqlSchema,
-          },
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageMapper,
+          mirageServer,
+          graphqlSchema,
         },
-      );
+      });
 
       const result = await handler.query(`{
           person {
@@ -377,17 +347,14 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         name: 'Grace Hopper',
       }));
 
-      const handler = await createGraphQLHandler(
-        {},
-        {
-          middlewares: [patchAutoFieldResolvers()],
-          dependencies: {
-            mirageMapper,
-            mirageServer,
-            graphqlSchema,
-          },
+      const handler = await createGraphQLHandler({
+        middlewares: [patchAutoFieldResolvers()],
+        dependencies: {
+          mirageMapper,
+          mirageServer,
+          graphqlSchema,
         },
-      );
+      });
 
       const result = await handler.query(`{
           person {
@@ -420,16 +387,13 @@ describe('integration/mirage-auto-resolve-root-query', function () {
       });
 
       it('when no field filter exists it throws an error', async function () {
-        const handler = await createGraphQLHandler(
-          {},
-          {
-            middlewares: [patchAutoFieldResolvers()],
-            dependencies: {
-              mirageServer,
-              graphqlSchema,
-            },
+        const handler = await createGraphQLHandler({
+          middlewares: [patchAutoFieldResolvers()],
+          dependencies: {
+            mirageServer,
+            graphqlSchema,
           },
-        );
+        });
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const result: any = await handler.query(`{
@@ -451,17 +415,14 @@ describe('integration/mirage-auto-resolve-root-query', function () {
             return models[0];
           });
 
-          const handler = await createGraphQLHandler(
-            {},
-            {
-              middlewares: [patchAutoFieldResolvers()],
-              dependencies: {
-                mirageServer,
-                graphqlSchema,
-                mirageMapper,
-              },
+          const handler = await createGraphQLHandler({
+            middlewares: [patchAutoFieldResolvers()],
+            dependencies: {
+              mirageServer,
+              graphqlSchema,
+              mirageMapper,
             },
-          );
+          });
 
           const result = await handler.query(`{
             person {
@@ -483,17 +444,14 @@ describe('integration/mirage-auto-resolve-root-query', function () {
             return models;
           });
 
-          const handler = await createGraphQLHandler(
-            {},
-            {
-              middlewares: [patchAutoFieldResolvers()],
-              dependencies: {
-                mirageServer,
-                graphqlSchema,
-                mirageMapper,
-              },
+          const handler = await createGraphQLHandler({
+            middlewares: [patchAutoFieldResolvers()],
+            dependencies: {
+              mirageServer,
+              graphqlSchema,
+              mirageMapper,
             },
-          );
+          });
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const result: any = await handler.query(`{

--- a/test/integration/mirage-auto-resolver.test.ts
+++ b/test/integration/mirage-auto-resolver.test.ts
@@ -28,7 +28,8 @@ describe('integration/mirage-auto-resolver', function () {
 
     mirageServer.db.loadData(defaultScenario);
 
-    const handler = await createGraphQLHandler(defaultResolvers, {
+    const handler = await createGraphQLHandler({
+      resolverMap: defaultResolvers,
       middlewares: [patchAutoResolvers()],
       dependencies: {
         mirageMapper,
@@ -534,21 +535,18 @@ describe('integration/mirage-auto-resolver', function () {
 
     context('with Query.allPersons included', () => {
       beforeEach(async () => {
-        const handler = await createGraphQLHandler(
-          {},
-          {
-            middlewares: [
-              patchAutoResolvers({
-                include: ['Query', 'allPersons'],
-              }),
-            ],
-            dependencies: {
-              mirageMapper,
-              mirageServer,
-              graphqlSchema: graphqlSchema,
-            },
+        const handler = await createGraphQLHandler({
+          middlewares: [
+            patchAutoResolvers({
+              include: ['Query', 'allPersons'],
+            }),
+          ],
+          dependencies: {
+            mirageMapper,
+            mirageServer,
+            graphqlSchema: graphqlSchema,
           },
-        );
+        });
 
         graphQLHandler = handler.query;
       });
@@ -577,21 +575,18 @@ describe('integration/mirage-auto-resolver', function () {
 
     context('with Query.allPersons excluded', () => {
       beforeEach(async () => {
-        const handler = await createGraphQLHandler(
-          {},
-          {
-            middlewares: [
-              patchAutoResolvers({
-                exclude: ['Query', 'allPersons'],
-              }),
-            ],
-            dependencies: {
-              mirageMapper,
-              mirageServer,
-              graphqlSchema: graphqlSchema,
-            },
+        const handler = await createGraphQLHandler({
+          middlewares: [
+            patchAutoResolvers({
+              exclude: ['Query', 'allPersons'],
+            }),
+          ],
+          dependencies: {
+            mirageMapper,
+            mirageServer,
+            graphqlSchema: graphqlSchema,
           },
-        );
+        });
 
         graphQLHandler = handler.query;
       });

--- a/test/integration/mirage-relay.test.ts
+++ b/test/integration/mirage-relay.test.ts
@@ -77,17 +77,14 @@ describe('integration/mirage-relay', function () {
 
     mirageMapper = new MirageGraphQLMapper().addFieldFilter(['Query', 'person'], () => rootPerson);
 
-    handler = await createGraphQLHandler(
-      {},
-      {
-        middlewares: [patchAutoFieldResolvers()],
-        dependencies: {
-          mirageServer,
-          mirageMapper,
-          graphqlSchema: schemaString,
-        },
+    handler = await createGraphQLHandler({
+      middlewares: [patchAutoFieldResolvers()],
+      dependencies: {
+        mirageServer,
+        mirageMapper,
+        graphqlSchema: schemaString,
       },
-    );
+    });
   });
 
   afterEach(() => {

--- a/test/integration/mirage-static-resolvers.test.ts
+++ b/test/integration/mirage-static-resolvers.test.ts
@@ -12,7 +12,8 @@ describe('integration/mirage-static-resolvers', function () {
   beforeEach(async () => {
     mirageServer.db.loadData(defaultScenario);
 
-    handler = await createGraphQLHandler(defaultResolvers, {
+    handler = await createGraphQLHandler({
+      resolverMap: defaultResolvers,
       state: {},
       dependencies: {
         mirageServer,

--- a/test/unit/graphql/handler.test.ts
+++ b/test/unit/graphql/handler.test.ts
@@ -29,7 +29,7 @@ describe('graphql/hander', function () {
   });
 
   it('can execute a graphql query constructed from a schema string', async function () {
-    handler = await createGraphQLHandler(resolverMap, { dependencies: { graphqlSchema: schemaString } });
+    handler = await createGraphQLHandler({ resolverMap, dependencies: { graphqlSchema: schemaString } });
     const result = await handler.query(`
       {
         hello
@@ -45,7 +45,7 @@ describe('graphql/hander', function () {
 
   it('can execute a graphql query constructed from a schema instance', async function () {
     const schemaInstance = buildSchema(schemaString);
-    handler = await createGraphQLHandler(resolverMap, { dependencies: { graphqlSchema: schemaInstance } });
+    handler = await createGraphQLHandler({ resolverMap, dependencies: { graphqlSchema: schemaInstance } });
     const result = await handler.query(`
       {
         hello
@@ -62,7 +62,8 @@ describe('graphql/hander', function () {
   it('throws a helpful error if the schema string cannot be parsed', async function () {
     let error: null | Error = null;
     try {
-      await createGraphQLHandler(resolverMap, {
+      await createGraphQLHandler({
+        resolverMap,
         dependencies: { graphqlSchema: 'NOT A VALID GRAPHQL STRING' },
       });
     } catch (e) {
@@ -77,7 +78,8 @@ Syntax Error: Unexpected Name "NOT"`);
 
   it('returns maintains the same state object argument', async function () {
     const initialState = { key: 'value' };
-    const handler = await createGraphQLHandler(resolverMap, {
+    const handler = await createGraphQLHandler({
+      resolverMap,
       state: initialState,
       dependencies: { graphqlSchema: schemaString },
     });
@@ -86,10 +88,8 @@ Syntax Error: Unexpected Name "NOT"`);
   });
 
   it('can use ResolverMap middlewares', async function () {
-    // using the wrapEachField middleware with the spyWrapper
-    // produces a state with the spy function accessible at
-    // state.spies.Query.hello
-    const handler = await createGraphQLHandler(resolverMap, {
+    const handler = await createGraphQLHandler({
+      resolverMap,
       middlewares: [embed({ wrappers: [spyWrapper] })],
       dependencies: { graphqlSchema: schemaString },
     });


### PR DESCRIPTION
The resolverMap as a first arg is not always required for `createGraphQLHandler` like it is for `pack`. If it was not used in `createGraphQLHandler` the first argument ends up being an empty object which doesn't read well. With it being optional, and included in the options hash, it allows for it to be specified only when needed. This API results in a cleaner usage. 