### PR TITLE
Switch to class-based GraphQL Handler

### DIFF
--- a/src/graphql/handler.ts
+++ b/src/graphql/handler.ts
@@ -1,47 +1,73 @@
-import { graphql, GraphQLSchema, ExecutionResult } from 'graphql';
+import { graphql, GraphQLSchema, ExecutionResult, GraphQLArgs } from 'graphql';
 import { pack } from '../pack';
 import { createSchema, attachResolversToSchema } from './utils';
 import { normalizePackOptions } from '../pack/utils';
-import { createGraphQLHandlerOptions, GraphQLHandler } from './types';
+import { CreateGraphQLHandlerOptions } from './types';
+import { ResolverMapMiddleware, ResolverMap } from '../types';
+import { PackOptions } from '../pack/types';
 
-export async function createGraphQLHandler(options: createGraphQLHandlerOptions): Promise<GraphQLHandler> {
-  const resolverMap = options?.resolverMap ?? {};
-  const graphqlSchema = createSchema(options?.dependencies?.graphqlSchema);
-  options.dependencies.graphqlSchema = graphqlSchema;
+export class GraphQLHandler {
+  state: PackOptions['state'];
 
-  const middlewares = options.middlewares ?? [];
-  const dependencies = options.dependencies;
-  const initialState = options.state;
+  protected packed = false;
+  protected packOptions: PackOptions;
+  protected middlewares: ResolverMapMiddleware[];
+  protected graphqlSchema: GraphQLSchema;
+  protected initialResolverMap: ResolverMap;
 
-  const packOptions = normalizePackOptions({
-    dependencies,
-    state: initialState,
-  });
+  constructor(options: CreateGraphQLHandlerOptions) {
+    const graphqlSchema = createSchema(options.dependencies?.graphqlSchema);
 
-  // pack middlewares against resolverMap
-  const { resolverMap: packedResolverMap } = await pack(resolverMap, middlewares, packOptions);
+    this.packOptions = normalizePackOptions({
+      dependencies: {
+        ...options.dependencies,
+        graphqlSchema,
+      },
+      state: options.state,
+    });
 
-  // apply resolverMap against copied graphql schema, attaching to schema:
-  attachResolversToSchema(packedResolverMap, graphqlSchema);
+    this.graphqlSchema = graphqlSchema;
+    this.initialResolverMap = options.resolverMap ?? {};
+    this.state = options.state ?? {};
+    this.middlewares = options.middlewares ?? [];
+  }
 
-  return {
-    state: packOptions.state,
-    dependencies: packOptions.dependencies,
-    packedResolverMap,
-    middlewares,
-    graphqlSchema,
+  async query(
+    query: GraphQLArgs['source'],
+    variables?: GraphQLArgs['variableValues'],
+    queryContext?: GraphQLArgs['contextValue'],
+    graphqlArgs?: GraphQLArgs,
+  ): Promise<ExecutionResult> {
+    await this.pack();
 
-    query: async (query, variables = {}, graphqlArgs): Promise<ExecutionResult> => {
-      if (typeof variables !== 'object') {
-        throw new Error(`Variables must be an object, got ${typeof variables}`);
-      }
+    variables = variables ?? {};
+    queryContext = queryContext ?? {};
 
-      return graphql({
-        schema: graphqlSchema as GraphQLSchema,
-        source: query,
-        variableValues: variables,
-        ...graphqlArgs,
-      });
-    },
-  };
+    if (typeof variables !== 'object') {
+      throw new Error(`Variables must be an object, got ${typeof variables}`);
+    }
+
+    return graphql({
+      schema: this.graphqlSchema,
+      source: query,
+      variableValues: variables,
+
+      ...graphqlArgs,
+
+      contextValue: {
+        ...graphqlArgs?.contextValue,
+        queryContext,
+      },
+    });
+  }
+
+  protected async pack(): Promise<void> {
+    if (!this.packed) {
+      const { resolverMap, state } = await pack(this.initialResolverMap, this.middlewares ?? [], this.packOptions);
+      this.state = state;
+      attachResolversToSchema(resolverMap, this.graphqlSchema);
+    }
+
+    this.packed = true;
+  }
 }

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -1,1 +1,1 @@
-export { createGraphQLHandler } from './handler';
+export { GraphQLHandler } from './handler';

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -1,22 +1,8 @@
-import { GraphQLSchema, GraphQLArgs, graphql } from 'graphql';
+import { GraphQLSchema } from 'graphql';
 import { ResolverMapMiddleware, ResolverMap } from '../types';
-import { PackState, PackOptions } from '../pack/types';
+import { PackOptions } from '../pack/types';
 
-export interface GraphQLHandler {
-  state: PackState;
-  dependencies: PackState['dependencies'];
-  graphqlSchema: GraphQLSchema;
-  middlewares: ResolverMapMiddleware[];
-  packedResolverMap: ResolverMap;
-
-  query: (
-    query: string,
-    variables?: Record<string, unknown>,
-    graphqlArgs?: Partial<GraphQLArgs>,
-  ) => ReturnType<typeof graphql>;
-}
-
-export type createGraphQLHandlerOptions = Partial<PackOptions> & {
+export type CreateGraphQLHandlerOptions = Partial<PackOptions> & {
   resolverMap?: ResolverMap;
   middlewares?: ResolverMapMiddleware[];
   dependencies: PackOptions['dependencies'] & { graphqlSchema: GraphQLSchema | string };

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -1,8 +1,9 @@
-import { GraphQLSchema } from 'graphql';
+import { GraphQLSchema, GraphQLArgs } from 'graphql';
 import { ResolverMapMiddleware, ResolverMap } from '../types';
 import { PackOptions } from '../pack/types';
 
 export type CreateGraphQLHandlerOptions = Partial<PackOptions> & {
+  initialContext?: GraphQLArgs['contextValue'];
   resolverMap?: ResolverMap;
   middlewares?: ResolverMapMiddleware[];
   dependencies: PackOptions['dependencies'] & { graphqlSchema: GraphQLSchema | string };

--- a/src/graphql/utils.ts
+++ b/src/graphql/utils.ts
@@ -1,4 +1,4 @@
-import { ResolverMap, ResolvableType, ResolvableField } from '../types';
+import { ResolverMap, ResolvableType, ResolvableField, ResolverContext } from '../types';
 import {
   GraphQLSchema,
   isAbstractType,
@@ -16,8 +16,10 @@ import {
   isSchema,
   buildSchema,
   printSchema,
+  GraphQLArgs,
 } from 'graphql';
 import { FieldReference } from '../resolver-map/reference/field-reference';
+import { PackOptions } from '../pack/types';
 
 export function attachTypeResolversToSchema(resolverMap: ResolverMap, schema: GraphQLSchema): void {
   for (const typeName in resolverMap) {
@@ -151,4 +153,20 @@ export function createSchema(schema: GraphQLSchema | string): GraphQLSchema {
   }
 
   throw new Error('Unable to build schema, pass in an instance of schema or a string');
+}
+
+export function buildContext({
+  initialContext,
+  queryContext,
+  packOptions,
+}: {
+  initialContext?: GraphQLArgs['contextValue'];
+  queryContext?: GraphQLArgs['contextValue'];
+  packOptions: PackOptions;
+}): ResolverContext {
+  return {
+    ...initialContext,
+    ...queryContext,
+    pack: packOptions,
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { createGraphQLHandler } from './graphql';
+export { GraphQLHandler } from './graphql';
 export { pack } from './pack';
 export { embed } from './resolver-map';

--- a/src/pack/types.ts
+++ b/src/pack/types.ts
@@ -1,4 +1,4 @@
-import { ResolverMapMiddleware, ResolverMap, ResolverContext } from '../types';
+import { ResolverMapMiddleware, ResolverMap } from '../types';
 
 type NonNullDependency = object | string | boolean | symbol | number;
 
@@ -16,7 +16,3 @@ export type Packer = (
   middlewares: ResolverMapMiddleware[],
   packOptions?: Partial<PackOptions>,
 ) => Promise<Packed>;
-
-export type PackedContext = ResolverContext & {
-  pack?: { dependencies?: PackOptions['dependencies'] };
-};

--- a/src/pack/utils.ts
+++ b/src/pack/utils.ts
@@ -1,6 +1,6 @@
 import { ResolverWrapper, ResolverParent, ResolverArgs, ResolverContext, ResolverInfo, Resolver } from '../types';
 import { defaultPackOptions } from './pack';
-import { PackOptions, PackedContext } from './types';
+import { PackOptions } from './types';
 
 export function normalizePackOptions(packOptions: Partial<PackOptions> = defaultPackOptions): PackOptions {
   const normalized = {
@@ -16,7 +16,7 @@ export function normalizePackOptions(packOptions: Partial<PackOptions> = default
 export const embedPackOptionsInContext = (
   context: Record<string, unknown>,
   packOptions: PackOptions,
-): PackedContext => {
+): ResolverContext => {
   context = context ?? {};
   context = {
     ...context,

--- a/src/resolver/extract-dependencies.ts
+++ b/src/resolver/extract-dependencies.ts
@@ -1,28 +1,27 @@
-import { PackOptions, PackedContext } from '../pack/types';
+import { PackOptions } from '../pack/types';
+import { ResolverContext } from '../types';
 
 type PackDependencies = PackOptions['dependencies'];
 
-export function extractAllDependencies<T = PackDependencies>(
-  context: PackedContext,
-): T extends PackDependencies ? Partial<T> : PackDependencies {
+export function extractAllDependencies<T extends PackDependencies>(context: ResolverContext): T {
   const packedDependencies = context?.pack?.dependencies ?? {};
-  return packedDependencies;
+  return packedDependencies as T;
 }
 
-export function extractDependencies<T>(
+export function extractDependencies<T extends PackDependencies>(
   requestedDependencies: (keyof T)[],
-  context: PackedContext,
+  context: ResolverContext,
   options?: { required: true },
 ): T extends PackDependencies ? Required<T> : Required<PackDependencies>;
-export function extractDependencies<T>(
+export function extractDependencies<T extends PackDependencies>(
   requestedDependencies: (keyof T)[],
-  context: PackedContext,
+  context: ResolverContext,
   options?: { required: false },
 ): T extends PackDependencies ? Partial<T> : Partial<PackDependencies>;
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function extractDependencies<T>(
+export function extractDependencies<T extends PackDependencies>(
   requestedDependencies: (keyof T)[],
-  context: PackedContext,
+  context: ResolverContext,
   options = { required: true },
 ) {
   const packedDependencies = extractAllDependencies<T>(context);
@@ -54,7 +53,7 @@ export function extractDependencies<T>(
     throw new Error(
       `Expected to find dependencies with keys: ${missingKeys}\n` +
         'Either:\n' +
-        ' * Add to the these `dependencies` in your `createGraphQLHandler` or `pack` function\n' +
+        ' * Add these to `dependencies` to your `GraphQLHandler` class or `pack` function\n' +
         ' * Use { required : false } as the third argument to `extractDependencies` and allow for these to be optional dependencies',
     );
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,11 +13,17 @@ import { PackOptions } from './pack/types';
 
 // Resolvers Shorthands
 
+type ManagedContext = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+  pack?: PackOptions;
+};
+
 export type Primitive = string | boolean | number;
 export type Resolver = GraphQLFieldResolver<any, any>;
 export type ResolverParent = Parameters<GraphQLFieldResolver<any, any>>[0];
 export type ResolverArgs = Parameters<GraphQLFieldResolver<any, any>>[1];
-export type ResolverContext = Parameters<GraphQLFieldResolver<any, any>>[2];
+export type ResolverContext = ManagedContext;
 export type ResolverInfo = Parameters<GraphQLFieldResolver<any, any>>[3];
 
 // Library Abstractions

--- a/test/integration/mirage-auto-resolve-object-types.test.ts
+++ b/test/integration/mirage-auto-resolve-object-types.test.ts
@@ -4,7 +4,7 @@
 import { Model, Server, hasMany, belongsTo } from 'miragejs';
 import { expect } from 'chai';
 import { patchAutoFieldResolvers } from '../../src/mirage/middleware/patch-auto-field-resolvers';
-import { createGraphQLHandler } from '../../src/graphql';
+import { GraphQLHandler } from '../../src/graphql';
 import { MirageGraphQLMapper } from '../../src/mirage/mapper/mapper';
 
 // patchAutoFieldResolvers middleware covers both auto-resolving of
@@ -54,7 +54,7 @@ describe('integration/mirage-auto-resolve-types', function () {
     });
 
     it('returns a scalar from a model attr', async () => {
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageServer,
@@ -84,7 +84,7 @@ describe('integration/mirage-auto-resolve-types', function () {
     it('returns a scalar from a field filter', async () => {
       mirageMapper.addFieldFilter(['Person', 'name'], () => 'Person Name Override');
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageMapper,
@@ -146,7 +146,7 @@ describe('integration/mirage-auto-resolve-types', function () {
     it('returns a collection of relationships from a model', async () => {
       mirageMapper.addFieldFilter(['Query', 'person'], () => rootPerson);
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageMapper,
@@ -201,7 +201,7 @@ describe('integration/mirage-auto-resolve-types', function () {
           return models.filter((model: any) => model?.name?.startsWith('M'));
         });
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageMapper,
@@ -259,7 +259,7 @@ describe('integration/mirage-auto-resolve-types', function () {
 
       mirageMapper.addFieldFilter(['Query', 'person'], () => rootPerson);
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageMapper,
@@ -311,7 +311,7 @@ describe('integration/mirage-auto-resolve-types', function () {
       mirageMapper.addFieldFilter(['Query', 'person'], () => rootPerson);
       mirageMapper.addFieldFilter(['Person', 'bestFriend'], () => bestFriendOverride);
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageMapper,

--- a/test/integration/mirage-auto-resolve-root-query.test.ts
+++ b/test/integration/mirage-auto-resolve-root-query.test.ts
@@ -4,7 +4,7 @@
 import { Model, Server } from 'miragejs';
 import { expect } from 'chai';
 import { patchAutoFieldResolvers } from '../../src/mirage/middleware/patch-auto-field-resolvers';
-import { createGraphQLHandler } from '../../src/graphql';
+import { GraphQLHandler } from '../../src/graphql';
 import { MirageGraphQLMapper } from '../../src/mirage/mapper/mapper';
 
 // patchAutoFieldResolvers middleware covers both auto-resolving of
@@ -31,7 +31,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     it('can return a scalar using a filter field', async function () {
       const mirageMapper = new MirageGraphQLMapper().addFieldFilter(['Query', 'personName'], () => 'Grace Hopper');
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageMapper,
@@ -61,7 +61,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         'Anita Borg',
       ]);
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageMapper,
@@ -86,7 +86,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     });
 
     it('throws an error when a field filter is not provided', async function () {
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageServer,
@@ -149,7 +149,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     `;
 
     it('by default returns an array of all models', async function () {
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageServer,
@@ -175,7 +175,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         return models.filter((model: any) => ['wilma', 'fred'].includes(model.name));
       });
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageServer,
@@ -202,7 +202,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         return [{ name: 'Ada Lovelace' }, { name: 'Grace Hopper' }];
       });
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageServer,
@@ -229,7 +229,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         return null;
       });
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageServer,
@@ -274,7 +274,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         name: 'fred',
       });
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageServer,
@@ -296,7 +296,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     });
 
     it('returns null when there are no models', async function () {
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageServer,
@@ -320,7 +320,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
     it('returns null from field filter', async function () {
       const mirageMapper = new MirageGraphQLMapper().addFieldFilter(['Query', 'person'], () => null);
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageMapper,
@@ -347,7 +347,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
         name: 'Grace Hopper',
       }));
 
-      const handler = await createGraphQLHandler({
+      const handler = new GraphQLHandler({
         middlewares: [patchAutoFieldResolvers()],
         dependencies: {
           mirageMapper,
@@ -387,7 +387,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
       });
 
       it('when no field filter exists it throws an error', async function () {
-        const handler = await createGraphQLHandler({
+        const handler = new GraphQLHandler({
           middlewares: [patchAutoFieldResolvers()],
           dependencies: {
             mirageServer,
@@ -415,7 +415,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
             return models[0];
           });
 
-          const handler = await createGraphQLHandler({
+          const handler = new GraphQLHandler({
             middlewares: [patchAutoFieldResolvers()],
             dependencies: {
               mirageServer,
@@ -444,7 +444,7 @@ describe('integration/mirage-auto-resolve-root-query', function () {
             return models;
           });
 
-          const handler = await createGraphQLHandler({
+          const handler = new GraphQLHandler({
             middlewares: [patchAutoFieldResolvers()],
             dependencies: {
               mirageServer,

--- a/test/integration/mirage-auto-resolver.test.ts
+++ b/test/integration/mirage-auto-resolver.test.ts
@@ -6,11 +6,10 @@ import { server as mirageServer } from './test-helpers/mirage-sample';
 import defaultScenario from './test-helpers/mirage-sample/fixtures';
 import { graphqlSchema } from './test-helpers/test-schema';
 import { ResolverMap } from '../../src/types';
-import { createGraphQLHandler } from '../../src/graphql';
+import { GraphQLHandler } from '../../src/graphql';
 
 describe('integration/mirage-auto-resolver', function () {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let graphQLHandler: any;
+  let graphQLHandler: GraphQLHandler;
   let resolvers: ResolverMap;
   let mirageMapper: MirageGraphQLMapper;
 
@@ -28,7 +27,7 @@ describe('integration/mirage-auto-resolver', function () {
 
     mirageServer.db.loadData(defaultScenario);
 
-    const handler = await createGraphQLHandler({
+    graphQLHandler = new GraphQLHandler({
       resolverMap: defaultResolvers,
       middlewares: [patchAutoResolvers()],
       dependencies: {
@@ -37,14 +36,12 @@ describe('integration/mirage-auto-resolver', function () {
         graphqlSchema: graphqlSchema,
       },
     });
-
-    graphQLHandler = handler.query;
   });
 
   this.afterEach(() => {
     mirageServer.db.emptyData();
     (resolvers as unknown) = undefined;
-    graphQLHandler = undefined;
+    (graphQLHandler as unknown) = undefined;
   });
 
   it('can handle a type look up', async function () {
@@ -58,7 +55,7 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
+    const result = await graphQLHandler.query(query);
     expect(result).to.deep.equal({
       data: {
         person: {
@@ -92,7 +89,7 @@ describe('integration/mirage-auto-resolver', function () {
       'Person.fullname <=> Person.name mapping exists',
     );
 
-    const result = await graphQLHandler(query);
+    const result = await graphQLHandler.query(query);
     expect(result).to.deep.equal({
       data: {
         person: {
@@ -113,7 +110,7 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
+    const result = await graphQLHandler.query(query);
 
     expect(result).to.deep.equal({
       data: {
@@ -154,7 +151,7 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
+    const result = await graphQLHandler.query(query);
 
     expect(result.data!.person.id).to.equal(result.data!.person.posts[0].author.id);
     expect(result.data!.person.name).to.equal(result.data!.person.posts[0].author.name);
@@ -176,7 +173,7 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
+    const result = await graphQLHandler.query(query);
     expect(result.data!.person.posts[0].comments[0].body).to.equal('I love the town of Bedrock!');
     expect(result.data!.person.posts[0].comments[0].author.name).to.equal('Barney Rubble');
   });
@@ -206,7 +203,7 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
+    const result = await graphQLHandler.query(query);
     const [fred, barnie, wilma] = result.data!.allPersons;
 
     expect(fred.name).to.equal('Fred Flinstone');
@@ -291,7 +288,7 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
+    const result = await graphQLHandler.query(query);
     const [firstPerson, secondPerson] = result.data!.allPersons;
 
     expect(firstPerson.name).to.equal('Fred Flinstone');
@@ -344,7 +341,7 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
+    const result = await graphQLHandler.query(query);
     const [firstPerson, secondPerson] = result.data!.allPersons;
 
     expect(firstPerson.name).to.equal('Fred Flinstone');
@@ -364,7 +361,7 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
+    const result = await graphQLHandler.query(query);
     const [firstPerson, secondPerson] = result.data!.allPersons;
 
     expect(firstPerson.name).to.equal('Fred Flinstone');
@@ -399,8 +396,8 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
-    const [fred, barney, wilma] = result.data.allPersons;
+    const result = await graphQLHandler.query(query);
+    const [fred, barney, wilma] = result.data!.allPersons;
 
     expect(fred).to.deep.equal({
       name: 'Fred Flinstone',
@@ -424,8 +421,8 @@ describe('integration/mirage-auto-resolver', function () {
       }
     }`;
 
-    const result = await graphQLHandler(query);
-    const [fred, barney, wilma] = result.data.allPersons;
+    const result = await graphQLHandler.query(query);
+    const [fred, barney, wilma] = result.data!.allPersons;
 
     expect(fred).to.deep.equal({
       name: 'Fred Flinstone',
@@ -461,11 +458,11 @@ describe('integration/mirage-auto-resolver', function () {
         }
       }`;
 
-      const result = await graphQLHandler(query);
+      const result = await graphQLHandler.query(query);
       expect(result.errors).to.equal(undefined);
 
-      const edges = result.data.allPersonsPaginated.edges;
-      const pageInfo = result.data.allPersonsPaginated.pageInfo;
+      const edges = result.data!.allPersonsPaginated.edges;
+      const pageInfo = result.data!.allPersonsPaginated.pageInfo;
       const firstPersonEdge = edges[0];
       const secondPersonEdge = edges[1];
 
@@ -507,8 +504,8 @@ describe('integration/mirage-auto-resolver', function () {
         }
       }`;
 
-      const result = await graphQLHandler(query);
-      const firstPerson = result.data.allPersons[0];
+      const result = await graphQLHandler.query(query);
+      const firstPerson = result.data!.allPersons[0];
 
       expect(firstPerson.name).to.equal('Fred Flinstone');
       expect(firstPerson.id).to.equal('1');
@@ -535,7 +532,7 @@ describe('integration/mirage-auto-resolver', function () {
 
     context('with Query.allPersons included', () => {
       beforeEach(async () => {
-        const handler = await createGraphQLHandler({
+        graphQLHandler = new GraphQLHandler({
           middlewares: [
             patchAutoResolvers({
               include: ['Query', 'allPersons'],
@@ -547,12 +544,10 @@ describe('integration/mirage-auto-resolver', function () {
             graphqlSchema: graphqlSchema,
           },
         });
-
-        graphQLHandler = handler.query;
       });
 
       it('can query on the auto-resolvers patched in by in the `include` option', async () => {
-        expect(await graphQLHandler(allPersonsQuery)).to.deep.equal({
+        expect(await graphQLHandler.query(allPersonsQuery)).to.deep.equal({
           data: {
             allPersons: [
               {
@@ -575,7 +570,7 @@ describe('integration/mirage-auto-resolver', function () {
 
     context('with Query.allPersons excluded', () => {
       beforeEach(async () => {
-        const handler = await createGraphQLHandler({
+        graphQLHandler = new GraphQLHandler({
           middlewares: [
             patchAutoResolvers({
               exclude: ['Query', 'allPersons'],
@@ -587,12 +582,10 @@ describe('integration/mirage-auto-resolver', function () {
             graphqlSchema: graphqlSchema,
           },
         });
-
-        graphQLHandler = handler.query;
       });
 
       it('can not query on excluded auto-resolvers ', async () => {
-        expect((await graphQLHandler(allPersonsQuery))?.errors?.[0]?.message).to.include(
+        expect((await graphQLHandler.query(allPersonsQuery))?.errors?.[0]?.message).to.include(
           'Cannot return null for non-nullable field Query.allPersons',
         );
       });

--- a/test/integration/mirage-relay.test.ts
+++ b/test/integration/mirage-relay.test.ts
@@ -4,9 +4,8 @@
 import { Model, Server, hasMany } from 'miragejs';
 import { expect } from 'chai';
 import { patchAutoFieldResolvers } from '../../src/mirage/middleware/patch-auto-field-resolvers';
-import { createGraphQLHandler } from '../../src/graphql';
-import { GraphQLHandler } from '../../src/graphql/types';
 import { MirageGraphQLMapper } from '../../src/mirage';
+import { GraphQLHandler } from '../../src/graphql';
 
 const schemaString = `
   schema {
@@ -77,7 +76,7 @@ describe('integration/mirage-relay', function () {
 
     mirageMapper = new MirageGraphQLMapper().addFieldFilter(['Query', 'person'], () => rootPerson);
 
-    handler = await createGraphQLHandler({
+    handler = new GraphQLHandler({
       middlewares: [patchAutoFieldResolvers()],
       dependencies: {
         mirageServer,

--- a/test/integration/mirage-static-resolvers.test.ts
+++ b/test/integration/mirage-static-resolvers.test.ts
@@ -3,8 +3,7 @@ import { graphqlSchema } from './test-helpers/test-schema';
 import defaultResolvers from './test-helpers/mirage-static-resolvers';
 import { server as mirageServer } from './test-helpers/mirage-sample';
 import defaultScenario from './test-helpers/mirage-sample/fixtures';
-import { createGraphQLHandler } from '../../src/graphql';
-import { GraphQLHandler } from '../../src/graphql/types';
+import { GraphQLHandler } from '../../src/graphql';
 
 describe('integration/mirage-static-resolvers', function () {
   let handler: GraphQLHandler;
@@ -12,7 +11,7 @@ describe('integration/mirage-static-resolvers', function () {
   beforeEach(async () => {
     mirageServer.db.loadData(defaultScenario);
 
-    handler = await createGraphQLHandler({
+    handler = new GraphQLHandler({
       resolverMap: defaultResolvers,
       state: {},
       dependencies: {

--- a/test/unit/resolver/extract-dependencies.test.ts
+++ b/test/unit/resolver/extract-dependencies.test.ts
@@ -13,7 +13,7 @@ const generateMocksContextWithDependencies = (dependencies: any): any => {
 
 const missingRequiredDependencyError = `Expected to find dependencies with keys: "does not exist"
 Either:
- * Add to the these \`dependencies\` in your \`createGraphQLHandler\` or \`pack\` function
+ * Add these to \`dependencies\` to your \`GraphQLHandler\` class or \`pack\` function
  * Use { required : false } as the third argument to \`extractDependencies\` and allow for these to be optional dependencies`;
 
 describe('resolvers/extract-dependencies', function () {


### PR DESCRIPTION
In the future the handler will have additional state and a class sets up for hooks and lifecycle methods.
* Changes the creation of the handler to a class and makes it synchronous
* The async operation of packing is deferred until the first query
* Add managed context including the spreading initial and query contexts