### PR TITLE
🏝👋🏽 Add mirage route handler 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         graphql-version: [14, 15]
-        miragejs-version: [0.1.36, latest]
+        miragejs-version: [0.1.40, latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0",
-    "miragejs": "^0.1.36"
+    "miragejs": "^0.1.40"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",
@@ -44,7 +44,7 @@
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.2",
     "graphql": "^14",
-    "miragejs": "^0.1.39",
+    "miragejs": "^0.1.40",
     "mocha": "^7.1.1",
     "np": "^6.2.3",
     "prettier": "^2.0.5",

--- a/src/graphql/handler.ts
+++ b/src/graphql/handler.ts
@@ -43,6 +43,7 @@ export class GraphQLHandler {
     const initialContext = this.initialContext;
     const packOptions = this.packOptions;
     const schema = this.graphqlSchema;
+
     variableValues = variableValues ?? {};
     queryContext = queryContext ?? {};
 
@@ -54,10 +55,6 @@ export class GraphQLHandler {
       packOptions,
     });
 
-    if (typeof variableValues !== 'object') {
-      throw new Error(`Variables must be an object, got ${typeof variableValues}`);
-    }
-
     return graphql({
       ...graphqlArgs,
       source: query,
@@ -68,10 +65,12 @@ export class GraphQLHandler {
   }
 
   protected async pack(): Promise<void> {
+    const { initialResolverMap, middlewares, packOptions, graphqlSchema } = this;
+
     if (!this.packed) {
-      const { resolverMap, state } = await pack(this.initialResolverMap, this.middlewares ?? [], this.packOptions);
+      const { resolverMap, state } = await pack(initialResolverMap, middlewares, packOptions);
       this.state = state;
-      attachResolversToSchema(resolverMap, this.graphqlSchema);
+      attachResolversToSchema(resolverMap, graphqlSchema);
     }
 
     this.packed = true;

--- a/src/mirage/route-handler.ts
+++ b/src/mirage/route-handler.ts
@@ -1,0 +1,25 @@
+import { Response } from 'miragejs';
+import { CreateGraphQLHandlerOptions } from '../graphql/types';
+import { MirageRouteHandler } from './types';
+import { GraphQLHandler } from '..';
+
+export function createRouteHandler(handlerOrOptions: CreateGraphQLHandlerOptions | GraphQLHandler): MirageRouteHandler {
+  const graphqlHandler =
+    handlerOrOptions instanceof GraphQLHandler ? handlerOrOptions : new GraphQLHandler(handlerOrOptions);
+
+  return async function graphQLHandler(_mirageSchema, request): Promise<ReturnType<MirageRouteHandler>> {
+    try {
+      const { query, variables } = JSON.parse(request.requestBody);
+      const result = await graphqlHandler.query(query, variables, { request });
+      return new Response(200, {}, result);
+    } catch (error) {
+      return new Response(
+        500,
+        {},
+        {
+          errors: [JSON.stringify(error)],
+        },
+      );
+    }
+  };
+}

--- a/src/mirage/types.ts
+++ b/src/mirage/types.ts
@@ -1,6 +1,7 @@
-import { ResolverParent, ResolverArgs, ResolverContext, ResolverInfo, Resolver } from '../types';
 import { ModelInstance } from 'miragejs';
+import { ResolverParent, ResolverArgs, ResolverContext, ResolverInfo, Resolver } from '../types';
 import { TypeName, FieldReference } from '../resolver-map/reference/field-reference';
+import { RouteHandler } from 'miragejs/server';
 
 type AutoFieldResolverType = 'OBJECT' | 'ROOT_TYPE';
 
@@ -60,3 +61,6 @@ export type RootQueryResolverMatch = {
   modelNameCandidates: string[];
   matchedModelName?: string;
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type MirageRouteHandler = RouteHandler<any>;

--- a/src/relay/utils.ts
+++ b/src/relay/utils.ts
@@ -6,36 +6,35 @@ export const createEdge = <T>(node: T, cursor: string): { cursor: string; node: 
 });
 
 export function applyCursorsToEdges<T = unknown>(
-  allEdges: Edge<T>[],
+  edges: Edge<T>[],
   cursorForNode: CursorForNode<T>,
   before?: string,
   after?: string,
 ): { edges: Edge<T>[]; frontCut: boolean; backCut: boolean } {
-  let edges = [...allEdges];
   let frontCut = false;
   let backCut = false;
 
   if (after) {
-    const afterEdge = allEdges.find((edge: Edge<T>) => cursorForNode(edge.node) === after);
+    const afterEdge = edges.find((edge: Edge<T>) => cursorForNode(edge.node) === after);
     if (!afterEdge) throw new Error(`${after} doesn't appear to be a valid edge`);
 
-    const afterEdgeIndex = allEdges.indexOf(afterEdge);
+    const afterEdgeIndex = edges.indexOf(afterEdge);
     const sliced = edges.slice(afterEdgeIndex + 1, edges.length);
     frontCut = sliced.length !== edges.length;
     edges = sliced;
   }
 
   if (before) {
-    const beforeEdge = allEdges.find((edge: Edge<T>) => cursorForNode(edge.node) === before);
+    const beforeEdge = edges.find((edge: Edge<T>) => cursorForNode(edge.node) === before);
     if (!beforeEdge) throw new Error(`${before} doesn't appear to be a valid edge`);
 
-    const beforeEdgeIndex = allEdges.indexOf(beforeEdge);
+    const beforeEdgeIndex = edges.indexOf(beforeEdge);
     const sliced = edges.slice(0, beforeEdgeIndex);
     backCut = sliced.length !== edges.length;
     edges = sliced;
   }
 
-  return { edges: edges, frontCut, backCut };
+  return { edges, frontCut, backCut };
 }
 
 export function relayPaginateNodes<T = unknown>(

--- a/test/integration/test-helpers/pretender.ts
+++ b/test/integration/test-helpers/pretender.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export class MockPretender {
+  handler: any;
+
+  async handleRequest(request: any): Promise<any> {
+    return this.handler(request);
+  }
+
+  async post(_: any, requestHandler: any): Promise<any> {
+    this.handler = requestHandler;
+  }
+}
+
+export function createMockRequest(query: string, variables?: Record<string, any>): any {
+  return {
+    url: '/graphql',
+    requestBody: JSON.stringify({
+      query,
+      variables,
+    }),
+  };
+}

--- a/test/unit/mirage/route-handler.test.ts
+++ b/test/unit/mirage/route-handler.test.ts
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+import { createServer } from 'miragejs';
+import { createRouteHandler } from '../../../src/mirage/route-handler';
+import { createMockRequest, MockPretender } from '../../integration/test-helpers/pretender';
+import { ResolverMap } from '../../../src/types';
+import { GraphQLHandler } from '../../../src';
+
+describe('mirage/route-handler', function () {
+  let graphqlSchema: string;
+  let resolverMap: ResolverMap;
+
+  beforeEach(() => {
+    graphqlSchema = `
+      schema {
+        query: Query
+      }
+
+      type Query {
+        hello: String!
+      }
+    `;
+
+    resolverMap = {
+      Query: {
+        hello(): string {
+          return 'Hello World!';
+        },
+      },
+    };
+  });
+
+  it('can create a mirage route handler with options', async function () {
+    const mockPretender = new MockPretender();
+
+    createServer({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pretender: mockPretender as any,
+
+      models: {},
+
+      routes() {
+        this.post(
+          'graphql',
+          createRouteHandler({
+            resolverMap,
+            dependencies: {
+              graphqlSchema,
+            },
+          }),
+        );
+      },
+    });
+
+    const result = await mockPretender.handleRequest(
+      createMockRequest(
+        `
+        {
+          hello
+        }
+      `,
+      ),
+    );
+
+    expect(result).to.deep.equal([
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({ data: { hello: 'Hello World!' } }),
+    ]);
+  });
+
+  it('can create a mirage route handler with a GraphQLHandler instance', async function () {
+    const mockPretender = new MockPretender();
+    const graphqlHandler = new GraphQLHandler({
+      resolverMap,
+      dependencies: {
+        graphqlSchema,
+      },
+    });
+
+    createServer({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pretender: mockPretender as any,
+
+      models: {},
+
+      routes() {
+        this.post('graphql', createRouteHandler(graphqlHandler));
+      },
+    });
+
+    const result = await mockPretender.handleRequest(
+      createMockRequest(
+        `
+        {
+          hello
+        }
+      `,
+      ),
+    );
+
+    expect(result).to.deep.equal([
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({ data: { hello: 'Hello World!' } }),
+    ]);
+  });
+});


### PR DESCRIPTION
If already mocking with Mirage JS in a browser then this route handler can setup `graphql-mocks` quickly with `createRouteHandler`. It takes either a `GraphQLHandler` instance or the options that would create an instance.

Within a route handler the server instance is `this` so it's easy to specify the `mirageServer` dependency:

```ts
const mirageServer = createServer({
  routes() {
    this.post(
      'graphql',
      createRouteHandler({
        resolverMap,
        dependencies: {

          // pass in mirage server dependency
          mirageServer: this,

          graphqlSchema,
        },
      }),
    );
  },
});
```
