### PR TITLE
🗺 Include Type/Model mapping in field mapping

### DIFF
--- a/src/mirage/mapper/mapper.ts
+++ b/src/mirage/mapper/mapper.ts
@@ -36,6 +36,12 @@ export class MirageGraphQLMapper {
       throw new Error(`Unable to use second argument Mirage Definition: ${error.message}`);
     }
 
+    const [typeName] = graphqlDef;
+    const [modelName] = mirageDef;
+    if (typeName !== modelName) {
+      this.addTypeMapping(typeName, modelName);
+    }
+
     this.fieldMappings.push({ graphql: graphqlDef, mirage: mirageDef });
 
     return this;

--- a/test/unit/mirage/mapper/mapper.test.ts
+++ b/test/unit/mirage/mapper/mapper.test.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { MirageGraphQLMapper } from '../../../../src/mirage/mapper/mapper';
+
+describe('mirage/mapper/mapper', function () {
+  let mapper: MirageGraphQLMapper;
+
+  beforeEach(() => {
+    mapper = new MirageGraphQLMapper();
+  });
+
+  context('addFieldMapping', () => {
+    it('adds associated Type/Model mapping', () => {
+      mapper.addFieldMapping(['Type', 'field'], ['Model', 'attr']);
+      expect(mapper.typeMappings[0]).to.deep.equal({ graphql: 'Type', mirage: 'Model' });
+    });
+
+    it('ignores Type/Model mapping when they are the same name', () => {
+      mapper.addFieldMapping(['Type', 'field'], ['Type', 'attr']);
+      expect(mapper.typeMappings.length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
When creating a field mapping the type and model are also specified. The mapping between these are likely also needed in most cases. In the future, it may be necessary to have a way of overriding, or opting out of this additional mapping.