### PR TITLE
🔝 Export createRouteHandler from graphql-mocks/mirage

### DIFF
--- a/src/mirage/index.ts
+++ b/src/mirage/index.ts
@@ -1,4 +1,5 @@
 export { MirageGraphQLMapper } from './mapper/mapper';
+export { createRouteHandler } from './route-handler';
 export { patchAutoFieldResolvers } from './middleware/patch-auto-field-resolvers';
 export { patchAutoTypeResolvers } from './middleware/patch-auto-type-resolvers';
 export { patchAutoResolvers } from './middleware/patch-auto-resolvers';

--- a/test/unit/mirage/route-handler.test.ts
+++ b/test/unit/mirage/route-handler.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { createServer } from 'miragejs';
-import { createRouteHandler } from '../../../src/mirage/route-handler';
+import { createRouteHandler } from '../../../src/mirage';
 import { createMockRequest, MockPretender } from '../../integration/test-helpers/pretender';
 import { ResolverMap } from '../../../src/types';
 import { GraphQLHandler } from '../../../src';


### PR DESCRIPTION
It'd be commonly used so better to exported directly from `graphql-mocks/mirage`.